### PR TITLE
Adding a server ci job

### DIFF
--- a/.github/workflows/server_ci.yml
+++ b/.github/workflows/server_ci.yml
@@ -1,0 +1,23 @@
+name: ci
+
+on: [push, pull_request]
+
+jobs:
+  server:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        
+      - name: Set up uv
+        run: curl -LsSf https://astral.sh/uv/0.4.3/install.sh | sh
+
+      - name: Set up python
+        run: uv python install
+
+      - name: Install the project
+        run: uv sync --all-extras --dev
+        working-directory: ./server
+
+      - name: Check format
+        run: uv run black . --check --verbose
+        working-directory: ./server


### PR DESCRIPTION
Inital setup for CI via github actions. Right now the only step that isn't setup is checking that the python code is formatted correctly (with black defaults). Once we have pytests to run we will be able to add them as a step in the server job.