### PR TITLE
Add server Dockerfile

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,0 +1,15 @@
+From python:3.12-slim
+
+# Install uv
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /bin/uv
+
+# Copy our app into the container
+COPY . /app
+
+# Install the application dependancies
+WORKDIR /app
+RUN uv sync --frozen --no-cache
+
+# Run the server
+CMD ["/app/.venv/bin/fastapi", "run", "/app/main.py", "--port", "80", "--host", "0.0.0.0"]
+

--- a/server/README.md
+++ b/server/README.md
@@ -1,3 +1,15 @@
 # Clueless Backend Code	
 This directory contains all server code and backend logic for the game. 
 The main server is built using [FastAPI](https://fastapi.tiangolo.com/) and the python environment is managed by [uv](https://docs.astral.sh/uv/) follow these links to their respective documentation.
+
+### Building the Image  
+To build a docker/podman image run:
+```bash
+docker build -t clueless-server .
+```
+
+then to run it:
+```bash
+docker run -p 8000:80 clueless-server
+```
+


### PR DESCRIPTION
Deploying the server will be much easier if we containerize it. This PR adds a dockerfile to build our app image and includes commands in the server README to build and run the app using docker/podman. 

Eventually, I will have the image be built, pushed, and ran in the cloud via our CI pipeline, but I can do that later when we actually want to deploy the server.

closes #24 