### PR TITLE
CD pipeline for the server

### DIFF
--- a/.github/workflows/server_deploy.yml
+++ b/.github/workflows/server_deploy.yml
@@ -1,0 +1,48 @@
+name: Deploy to Cloud Run
+
+env:
+  SERVICE_NAME: clueless-server
+  PROJECT_ID:  clueless-435801
+  DOCKER_IMAGE_URL: us-central1-docker.pkg.dev/clueless-435801/clueless-server/clueless-server
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  dockerize-and-deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Google Cloud Auth
+        uses: 'google-github-actions/auth@v2'
+        with:
+          credentials_json: '${{ secrets.GCP_SA_KEY }}'
+          project_id: ${{ env.PROJECT_ID }}
+
+      - name: Set up Cloud SDK
+        uses: 'google-github-actions/setup-gcloud@v2'
+
+      - name: Configure Docker
+        run: |
+          gcloud auth configure-docker us-central1-docker.pkg.dev
+
+      - name: Build and Push Docker Image
+        run: |
+          docker build -t ${{ env.DOCKER_IMAGE_URL }}:latest -f Dockerfile .
+          docker push ${{ env.DOCKER_IMAGE_URL }}:latest
+        working-directory: ./server
+
+      - name: Deploy to Cloud Run
+        run: |
+          echo SERVICE_NAME $SERVICE_NAME
+          gcloud run deploy $SERVICE_NAME \
+            --image ${{ env.DOCKER_IMAGE_URL }}:latest \
+            --platform managed \
+            --region us-east1 \
+            --allow-unauthenticated \
+            --port 80


### PR DESCRIPTION
This yml file runs a GitHub action to build and deploy the docker image for our server to my personal Google Cloud account. This pipeline will run every time the `main` branch gets updated (ie whenever we merge in a PR).

If you want to see what a run looks like you can check it out [here](https://github.com/Jake-Funk/clueless/actions/runs/10893294719/job/30227918536)

The server should always be accessible at https://clueless-server-915069415929.us-east1.run.app 
NOTE: Since this server is running on my personal cloud account, I have set the server to sleep after not receiving any requests for a few minuets. This means you may notice slow startups/response times if you hit any endpoints while the server is sleeping.

Again, if you guys have any questions at all please lmk!