### PR TITLE
Fix/44 phase of game

### DIFF
--- a/server/util/game_state.py
+++ b/server/util/game_state.py
@@ -109,7 +109,9 @@ class GameState:
         for i in range(num_players):
             randCharacter = random.choice(allCharacters)
             self.player_character_mapping["player" + str(i + 1)] = randCharacter
-            self.player_character_mapping[randCharacter] = "player" + str(i + 1) # have the map store both directions of the mapping 
+            self.player_character_mapping[randCharacter] = "player" + str(
+                i + 1
+            )  # have the map store both directions of the mapping
             allCharacters.remove(randCharacter)
 
         self.map: Dict[RoomEnum | HallEnum, list[PlayerEnum]] = {}


### PR DESCRIPTION
Closes #44. Adds a section of the returned game_state dictionary that contains the phase of the game. The GameTurn  class as implemented uses an int to relate the player to the character enum. To make it easier on us, I made it so that the character-to-player mapping dictionary was bidirectional. This will hopefully make it easier for us to just query for the characterEnum at map index GameTurn.player and get the player (e.g., "player3") whose turn it is.