### PR TITLE
Fix/44 phase of game

### DIFF
--- a/server/util/game_state.py
+++ b/server/util/game_state.py
@@ -110,9 +110,6 @@ class GameState:
             randCharacter = random.choice(allCharacters)
             player_id = "player" + str(i + 1)
             self.player_character_mapping[player_id] = randCharacter
-            self.player_character_mapping[randCharacter] = (
-                player_id  # have the map store both directions of the mapping
-            )
             allCharacters.remove(randCharacter)
 
         self.map: Dict[RoomEnum | HallEnum, list[PlayerEnum]] = {}


### PR DESCRIPTION
Closes #44. Added a return for the game state dictionary for the game phase. I played around with making the player_character_mapping dictionary bidirectional by including the reverse mapping, but it would mess with some logic in the suggestion endpoint.